### PR TITLE
Fix TypeScript config in typechecking mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "clean": "rimraf built",
-    "typecheck": "tsc --noEmit -p .",
+    "typecheck": "tsc --noEmit --composite false -p .",
     "lint": "tslint -p ./tsconfig.json",
     "bundle": "microbundle -f es,umd --tsconfig ./tsconfig.json",
     "build": "npm run clean && npm run typecheck && npm run lint && npm run bundle",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "clean": "rimraf built",
-    "typecheck": "tsc --noEmit --composite false -p .",
+    "typecheck": "tsc --noEmit -p .",
     "lint": "tslint -p ./tsconfig.json",
     "bundle": "microbundle -f es,umd --tsconfig ./tsconfig.json",
     "build": "npm run clean && npm run typecheck && npm run lint && npm run bundle",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
 
-    "composite": true,
     "declaration": true,
     "declarationMap": true
   },


### PR DESCRIPTION
As described in https://github.com/microsoft/TypeScript/issues/36917, recent versions of TypeScript don't allow the `--noEmit` flag to be set alongside `"composite": true`. This PR updates the `typecheck` script to pass `--composite false` to `tsc` to fix this.

Side note: what do you think about committing a `package-lock.json` file to the repo? That would help ensure that everyone is working with the expected versions of dev dependencies.