### PR TITLE
Corrected types path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "source": "src/index.ts",
   "main": "built/index.umd.js",
   "module": "built/index.esm.js",
-  "types": "built/src/index.d.ts",
+  "types": "built/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "react",


### PR DESCRIPTION
Types in package.json was set to the incorrect path. Should fix #11.

To test:
`npm run build`
`index.d.ts` should be in `built`